### PR TITLE
Prevent regro autotick bot from breaking the license line again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: mitmproxy-rs
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   script:
     {% set _pip_cmd = PYTHON + " -m pip install -vv --no-deps --no-build-isolation" %}
@@ -100,8 +100,8 @@ about:
   home: http://mitmproxy.org
   summary: An interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers.
   license: >-
-    MIT AND BSD-3-Clause AND LGPL-2.0-only
-    AND (LGPL-3.0-only OR GPL-2.0-only)  # [win]
+    MIT AND BSD-3-Clause AND LGPL-2.0-only  # [not win]
+    MIT AND BSD-3-Clause AND LGPL-2.0-only AND (LGPL-3.0-only OR GPL-2.0-only)  # [win]
   license_file:
     - mitmproxy/LICENSE
     - aioquic_mitmproxy/LICENSE


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
